### PR TITLE
feat: enable manual window dragging for frameless overlay

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -242,6 +242,15 @@ ipcMain.on(IPC.SET_IGNORE_MOUSE_EVENTS, (event, ignore: boolean, options?: { for
   }
 })
 
+// Manual window drag — works reliably with frameless + setIgnoreMouseEvents
+ipcMain.on(IPC.START_WINDOW_DRAG, (event, deltaX: number, deltaY: number) => {
+  const win = BrowserWindow.fromWebContents(event.sender)
+  if (win && !win.isDestroyed()) {
+    const [x, y] = win.getPosition()
+    win.setPosition(x + deltaX, y + deltaY)
+  }
+})
+
 // ─── IPC Handlers (typed, strict) ───
 
 ipcMain.handle(IPC.START, async () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -66,6 +66,8 @@ export interface CluiAPI {
   isVisible(): Promise<boolean>
   /** OS-level click-through for transparent window regions */
   setIgnoreMouseEvents(ignore: boolean, options?: { forward?: boolean }): void
+  /** Manual window drag for frameless windows */
+  startWindowDrag(deltaX: number, deltaY: number): void
 
   // ─── Event listeners (main → renderer) ───
   onEvent(callback: (tabId: string, event: NormalizedEvent) => void): () => void
@@ -124,6 +126,8 @@ const api: CluiAPI = {
   isVisible: () => ipcRenderer.invoke(IPC.IS_VISIBLE),
   setIgnoreMouseEvents: (ignore, options) =>
     ipcRenderer.send(IPC.SET_IGNORE_MOUSE_EVENTS, ignore, options || {}),
+  startWindowDrag: (deltaX, deltaY) =>
+    ipcRenderer.send(IPC.START_WINDOW_DRAG, deltaX, deltaY),
   setWindowWidth: (width) => ipcRenderer.send(IPC.SET_WINDOW_WIDTH, width),
 
   // ─── Event listeners ───

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react'
+import React, { useEffect, useCallback, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Paperclip, Camera, HeadCircuit } from '@phosphor-icons/react'
 import { TabStrip } from './components/TabStrip'
@@ -90,6 +90,44 @@ export default function App() {
     return () => {
       document.removeEventListener('mousemove', onMouseMove)
       document.removeEventListener('mouseleave', onMouseLeave)
+    }
+  }, [])
+
+  // Manual window drag — bypasses -webkit-app-region conflicts with setIgnoreMouseEvents
+  const dragRef = useRef<{ startX: number; startY: number } | null>(null)
+  useEffect(() => {
+    if (!window.nusoma?.startWindowDrag) return
+
+    const onMouseDown = (e: MouseEvent) => {
+      const el = e.target as HTMLElement
+      // Only start drag if directly on a drag-region, not on a no-drag child
+      if (!el.closest('.drag-region') || el.closest('.no-drag')) return
+      e.preventDefault()
+      dragRef.current = { startX: e.screenX, startY: e.screenY }
+    }
+
+    const onMouseMove = (e: MouseEvent) => {
+      if (!dragRef.current) return
+      const dx = e.screenX - dragRef.current.startX
+      const dy = e.screenY - dragRef.current.startY
+      if (dx !== 0 || dy !== 0) {
+        window.nusoma.startWindowDrag(dx, dy)
+        dragRef.current.startX = e.screenX
+        dragRef.current.startY = e.screenY
+      }
+    }
+
+    const onMouseUp = () => {
+      dragRef.current = null
+    }
+
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mouseup', onMouseUp)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', onMouseUp)
     }
   }, [])
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -358,6 +358,7 @@ export const IPC = {
   HIDE_WINDOW: 'nusoma:hide-window',
   WINDOW_SHOWN: 'nusoma:window-shown',
   SET_IGNORE_MOUSE_EVENTS: 'nusoma:set-ignore-mouse-events',
+  START_WINDOW_DRAG: 'nusoma:start-window-drag',
   IS_VISIBLE: 'nusoma:is-visible',
 
   // Skill provisioning (main → renderer)


### PR DESCRIPTION
## Summary

- Adds manual window drag via IPC — tracks mouse deltas on `mousedown`/`mousemove` over `.drag-region` elements and repositions the window directly via `BrowserWindow.setPosition()`
- Bypasses the conflict between `-webkit-app-region: drag` and `setIgnoreMouseEvents` toggling, which prevents native Electron drag from working on frameless transparent panels
- Drag is scoped to `.drag-region` elements only; `.no-drag` children (tabs, input, chat) remain interactive

## Root cause

The overlay uses `setIgnoreMouseEvents(true, { forward: true })` for click-through on transparent regions, toggling it off when the cursor enters `[data-nusoma-ui]` elements. This conflicts with Electron native `-webkit-app-region: drag` — the drag never initiates because the mouse event state toggles too late in the event cycle.

## Changes

| File | Change |
|------|--------|
| `src/shared/types.ts` | Add `START_WINDOW_DRAG` IPC channel |
| `src/main/index.ts` | Handle drag IPC — apply position delta to window |
| `src/preload/index.ts` | Expose `startWindowDrag` to renderer |
| `src/renderer/App.tsx` | Add `mousedown`/`mousemove`/`mouseup` drag handler |

## Test plan

- [ ] Build and launch nusoma
- [ ] Hover over the card border area (the `.drag-region` between tabs and edges)
- [ ] Click and drag — window should follow the cursor
- [ ] Verify tabs, input bar, and chat content remain clickable (not draggable)
- [ ] Verify click-through on transparent areas still works

Ported from lcoutodemos/clui-cc#27

🤖 Generated with [Claude Code](https://claude.com/claude-code)