### PR TITLE
Add tab pinning, renaming, and keyboard shortcuts

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,6 +13,8 @@ import { DEFAULT_SHORTCUT_SETTINGS, IPC } from '../shared/types'
 import type { RunOptions, NormalizedEvent, EnrichedError, ShortcutSettings } from '../shared/types'
 import { loadShortcutSettings, registerShortcutSettings, saveShortcutSettings } from './shortcut-settings'
 
+app.disableHardwareAcceleration()
+
 const DEBUG_MODE = process.env.CLUI_DEBUG === '1'
 const SPACES_DEBUG = DEBUG_MODE || process.env.CLUI_SPACES_DEBUG === '1'
 
@@ -954,6 +956,34 @@ app.whenReady().then(async () => {
   registerPmHandlers()
   createWindow()
   snapshotWindowState('after createWindow')
+
+  // Override default app menu to remove Cmd+W (Close Window) — renderer handles it as close-tab
+  Menu.setApplicationMenu(Menu.buildFromTemplate([
+    {
+      label: app.name,
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' },
+      ],
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'selectAll' },
+      ],
+    },
+  ]))
 
   if (SPACES_DEBUG) {
     mainWindow?.on('show', () => snapshotWindowState('event window show'))

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -93,6 +93,37 @@ export default function App() {
     }
   }, [])
 
+  // ─── Cmd+1..9 tab switching, Cmd+T new tab, Cmd+W close tab ───
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!e.metaKey && !e.ctrlKey) return
+      if (e.key === 't' || e.key === 'T') {
+        e.preventDefault()
+        useSessionStore.getState().createTab()
+        return
+      }
+
+      if (e.key === 'w' || e.key === 'W') {
+        e.preventDefault()
+        const { activeTabId, closeTab } = useSessionStore.getState()
+        closeTab(activeTabId)
+        return
+      }
+
+      const digit = parseInt(e.key, 10)
+      if (digit < 1 || digit > 9 || isNaN(digit)) return
+
+      e.preventDefault()
+      const { tabs, selectTab } = useSessionStore.getState()
+      const index = digit - 1
+      if (index < tabs.length) {
+        selectTab(tabs[index].id)
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+
   const isExpanded = useSessionStore((s) => s.isExpanded)
   const marketplaceOpen = useSessionStore((s) => s.marketplaceOpen)
   const pmOpen = usePmStore((s) => s.pmOpen)

--- a/src/renderer/components/TabStrip.tsx
+++ b/src/renderer/components/TabStrip.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Plus, X, Kanban } from '@phosphor-icons/react'
+import { Plus, X, Kanban, PushPin, PushPinSlash } from '@phosphor-icons/react'
 import { useSessionStore } from '../stores/sessionStore'
 import { usePmStore } from '../stores/pmStore'
 import { HistoryPicker } from './HistoryPicker'
@@ -43,10 +43,25 @@ export function TabStrip() {
   const selectTab = useSessionStore((s) => s.selectTab)
   const createTab = useSessionStore((s) => s.createTab)
   const closeTab = useSessionStore((s) => s.closeTab)
+  const togglePin = useSessionStore((s) => s.togglePin)
+  const renameTab = useSessionStore((s) => s.renameTab)
+
   const colors = useColors()
   const pmOpen = usePmStore((s) => s.pmOpen)
   const openPm = usePmStore((s) => s.openPm)
   const closePm = usePmStore((s) => s.closePm)
+
+  const [editingTabId, setEditingTabId] = useState<string | null>(null)
+  const [editValue, setEditValue] = useState('')
+  const editRef = useRef<HTMLInputElement>(null)
+  const clickTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (editingTabId && editRef.current) {
+      editRef.current.focus()
+      editRef.current.select()
+    }
+  }, [editingTabId])
 
   return (
     <div
@@ -80,7 +95,11 @@ export function TabStrip() {
                   animate={{ opacity: 1, scale: 1 }}
                   exit={{ opacity: 0, scale: 0.9 }}
                   transition={{ duration: 0.15 }}
-                  onClick={() => selectTab(tab.id)}
+                  onClick={() => {
+                    if (clickTimer.current) { clearTimeout(clickTimer.current); clickTimer.current = null; return }
+                    clickTimer.current = setTimeout(() => { clickTimer.current = null; selectTab(tab.id) }, 200)
+                  }}
+                  onContextMenu={(e) => { e.preventDefault(); togglePin(tab.id) }}
                   className="group flex items-center gap-1.5 cursor-pointer select-none flex-shrink-0 max-w-[160px] transition-all duration-150"
                   style={{
                     background: isActive ? colors.tabActive : 'transparent',
@@ -92,9 +111,48 @@ export function TabStrip() {
                     fontWeight: isActive ? 500 : 400,
                   }}
                 >
+                  {tab.pinned && (
+                    <PushPin size={10} weight="fill" className="flex-shrink-0" style={{ color: colors.textTertiary }} />
+                  )}
                   <StatusDot status={tab.status} hasUnread={tab.hasUnread} hasPermission={tab.permissionQueue.length > 0} />
-                  <span className="truncate flex-1">{tab.title}</span>
-                  {tabs.length > 1 && (
+                  {editingTabId === tab.id ? (
+                    <input
+                      ref={editRef}
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      onBlur={() => { renameTab(tab.id, editValue); setEditingTabId(null) }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') { renameTab(tab.id, editValue); setEditingTabId(null) }
+                        if (e.key === 'Escape') setEditingTabId(null)
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                      className="truncate flex-1 bg-transparent outline-none border-none"
+                      style={{ fontSize: 12, color: 'inherit', fontWeight: 'inherit', padding: 0, margin: 0, width: '100%' }}
+                    />
+                  ) : (
+                    <span
+                      className="truncate flex-1"
+                      onDoubleClick={(e) => {
+                        e.stopPropagation()
+                        if (clickTimer.current) { clearTimeout(clickTimer.current); clickTimer.current = null }
+                        setEditingTabId(tab.id); setEditValue(tab.title)
+                      }}
+                    >
+                      {tab.title}
+                    </span>
+                  )}
+                  {tab.pinned ? (
+                    <button
+                      onClick={(e) => { e.stopPropagation(); togglePin(tab.id) }}
+                      className="flex-shrink-0 rounded-full w-4 h-4 flex items-center justify-center transition-opacity"
+                      style={{ opacity: 0, color: colors.textSecondary }}
+                      onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.opacity = '1' }}
+                      onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.opacity = '0' }}
+                      title="Unpin tab"
+                    >
+                      <PushPinSlash size={10} />
+                    </button>
+                  ) : tabs.length > 1 ? (
                     <button
                       onClick={(e) => { e.stopPropagation(); closeTab(tab.id) }}
                       className="flex-shrink-0 rounded-full w-4 h-4 flex items-center justify-center transition-opacity"
@@ -107,7 +165,7 @@ export function TabStrip() {
                     >
                       <X size={10} />
                     </button>
-                  )}
+                  ) : null}
                 </motion.div>
               )
             })}

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -72,6 +72,8 @@ interface State {
   addDirectory: (dir: string) => void
   removeDirectory: (dir: string) => void
   setBaseDirectory: (dir: string) => void
+  togglePin: (tabId: string) => void
+  renameTab: (tabId: string, title: string) => void
   addAttachments: (attachments: Attachment[]) => void
   removeAttachment: (attachmentId: string) => void
   clearAttachments: () => void
@@ -121,6 +123,42 @@ function makeLocalTab(): TabState {
     workingDirectory: '~',
     hasChosenDirectory: false,
     additionalDirs: [],
+    pinned: false,
+  }
+}
+
+// ─── Pinned tabs persistence ───
+
+interface PinnedTabData {
+  claudeSessionId: string
+  title: string
+  workingDirectory: string
+  additionalDirs: string[]
+}
+
+const PINNED_STORAGE_KEY = 'nusoma-pinned-tabs'
+
+function savePinnedTabs(tabs: TabState[]): void {
+  const pinned: PinnedTabData[] = tabs
+    .filter((t) => t.pinned && t.claudeSessionId)
+    .map((t) => ({
+      claudeSessionId: t.claudeSessionId!,
+      title: t.title,
+      workingDirectory: t.workingDirectory,
+      additionalDirs: t.additionalDirs,
+    }))
+  try {
+    localStorage.setItem(PINNED_STORAGE_KEY, JSON.stringify(pinned))
+  } catch {}
+}
+
+function loadPinnedTabs(): PinnedTabData[] {
+  try {
+    const raw = localStorage.getItem(PINNED_STORAGE_KEY)
+    if (!raw) return []
+    return JSON.parse(raw) as PinnedTabData[]
+  } catch {
+    return []
   }
 }
 
@@ -159,6 +197,39 @@ export const useSessionStore = create<State>((set, get) => ({
           homePath: result.homePath || '~',
         },
       })
+
+      // Restore pinned tabs from previous session
+      const pinnedData = loadPinnedTabs()
+      for (const p of pinnedData) {
+        try {
+          const { tabId } = await window.nusoma.createTab()
+          const history = await window.nusoma.loadSession(p.claudeSessionId, p.workingDirectory).catch(() => [])
+          let msgCounter2 = 0
+          const messages: Message[] = history.map((m) => ({
+            id: `pinned-${++msgCounter2}`,
+            role: m.role as Message['role'],
+            content: m.content,
+            toolName: m.toolName,
+            toolStatus: m.toolName ? 'completed' as const : undefined,
+            timestamp: m.timestamp,
+          }))
+
+          const tab: TabState = {
+            ...makeLocalTab(),
+            id: tabId,
+            claudeSessionId: p.claudeSessionId,
+            title: p.title,
+            workingDirectory: p.workingDirectory,
+            hasChosenDirectory: true,
+            additionalDirs: p.additionalDirs,
+            messages,
+            pinned: true,
+          }
+          set((s) => ({
+            tabs: [tab, ...s.tabs],
+          }))
+        } catch {}
+      }
     } catch {}
   },
 
@@ -355,7 +426,37 @@ export const useSessionStore = create<State>((set, get) => ({
     }, 100)
   },
 
+  togglePin: (tabId) => {
+    set((s) => {
+      const tabs = s.tabs.map((t) =>
+        t.id === tabId ? { ...t, pinned: !t.pinned } : t
+      )
+      // Sort: pinned tabs first, preserve relative order within each group
+      const pinned = tabs.filter((t) => t.pinned)
+      const unpinned = tabs.filter((t) => !t.pinned)
+      const sorted = [...pinned, ...unpinned]
+      savePinnedTabs(sorted)
+      return { tabs: sorted }
+    })
+  },
+
+  renameTab: (tabId, title) => {
+    const trimmed = title.trim()
+    if (!trimmed) return
+    set((s) => {
+      const tabs = s.tabs.map((t) =>
+        t.id === tabId ? { ...t, title: trimmed } : t
+      )
+      savePinnedTabs(tabs)
+      return { tabs }
+    })
+  },
+
   closeTab: (tabId) => {
+    // Prevent closing pinned tabs
+    const tab = get().tabs.find((t) => t.id === tabId)
+    if (tab?.pinned) return
+
     window.nusoma.closeTab(tabId).catch(() => {})
 
     const s = get()
@@ -653,6 +754,10 @@ export const useSessionStore = create<State>((set, get) => ({
             updated.sessionMcpServers = event.mcpServers
             updated.sessionSkills = event.skills
             updated.sessionVersion = event.version
+            // Persist pinned tabs when session ID is assigned
+            if (updated.pinned) {
+              setTimeout(() => savePinnedTabs(get().tabs), 0)
+            }
             // Don't change status/activity for warmup inits — they're invisible
             if (!event.isWarmup) {
               updated.status = 'running'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -170,6 +170,8 @@ export interface TabState {
   hasChosenDirectory: boolean
   /** Extra directories accessible via --add-dir (session-preserving) */
   additionalDirs: string[]
+  /** Whether this tab is pinned (persists across restarts) */
+  pinned: boolean
 }
 
 export interface Message {


### PR DESCRIPTION
## Summary
This PR adds persistent tab pinning, tab renaming, and keyboard shortcuts for tab management. Pinned tabs are restored across application restarts, and users can now manage tabs more efficiently with keyboard commands and UI interactions.

## Key Changes

- **Tab Pinning**: Added `togglePin()` action to pin/unpin tabs. Pinned tabs are sorted to the top and persist across restarts via localStorage
- **Tab Renaming**: Added `renameTab()` action allowing users to double-click tab titles to edit them inline
- **Keyboard Shortcuts**: Implemented Cmd/Ctrl+T (new tab), Cmd/Ctrl+W (close tab), and Cmd/Ctrl+1-9 (switch to tab by number)
- **UI Enhancements**: 
  - Right-click context menu on tabs to toggle pin state
  - Pin icon indicator on pinned tabs
  - Unpin button visible on hover for pinned tabs
  - Double-click to rename tab titles
- **Session Restoration**: Pinned tabs are automatically restored on app startup with their session history and working directory
- **Close Tab Protection**: Prevents closing pinned tabs via the close button
- **App Menu**: Customized application menu to avoid conflicts with renderer-handled Cmd+W shortcut
- **Hardware Acceleration**: Disabled hardware acceleration for stability

## Implementation Details

- Pinned tab data (session ID, title, working directory, additional directories) is serialized to localStorage under the `nusoma-pinned-tabs` key
- Tab sorting maintains pinned tabs at the top while preserving relative order within each group
- Double-click detection uses a timer to distinguish between single-click (select) and double-click (rename) actions
- Tab renaming updates both the UI state and persisted pinned tab data
- Keyboard shortcuts are registered globally in the renderer process and delegate to store actions

https://claude.ai/code/session_01Pd7Sh2GUqcymnffXtQjGdf