### PR TITLE
Add WhisperKit support as preferred transcription backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ claude
 **Step 6.** Install Whisper for voice input:
 
 ```bash
-brew install whisper-cli
+brew install whisperkit-cli
 ```
 
 > **No API keys or `.env` file required.** nusoma uses your existing Claude Code CLI authentication (Pro/Team/Enterprise subscription).

--- a/commands/install-app.command
+++ b/commands/install-app.command
@@ -35,7 +35,7 @@ fi
 
 step "Step 2/6 — Checking voice support (Whisper)"
 
-if command -v whisper-cli &>/dev/null || command -v whisper &>/dev/null; then
+if command -v whisperkit-cli &>/dev/null || command -v whisper-cli &>/dev/null || command -v whisper &>/dev/null; then
   echo "Whisper is already installed."
 else
   echo "Whisper is not installed. Voice input requires it."
@@ -54,12 +54,12 @@ else
 
   echo "Installing Whisper via Homebrew..."
   echo
-  if ! brew install whisper-cli; then
+  if ! brew install whisperkit-cli; then
     echo
     echo "Whisper installation failed."
     echo
     echo "  Try running manually:"
-    echo "    brew install whisper-cli"
+    echo "    brew install whisperkit-cli"
     echo
     echo "  Then double-click this file again."
     echo
@@ -67,12 +67,12 @@ else
   fi
 
   # Verify
-  if ! command -v whisper-cli &>/dev/null && ! command -v whisper &>/dev/null; then
+  if ! command -v whisperkit-cli &>/dev/null && ! command -v whisper-cli &>/dev/null && ! command -v whisper &>/dev/null; then
     echo
     echo "Whisper was installed but the command is not available."
     echo
     echo "  Try opening a new Terminal window and running:"
-    echo "    whisper-cli --help"
+    echo "    whisperkit-cli --help"
     echo
     echo "  If that works, double-click this file again."
     echo

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -659,8 +659,10 @@ ipcMain.handle(IPC.TRANSCRIBE_AUDIO, async (_event, audioBase64: string) => {
     const buf = Buffer.from(audioBase64, 'base64')
     writeFileSync(tmpWav, buf)
 
-    // Find whisper-cli (whisper-cpp homebrew) or whisper (python)
+    // Find whisperkit-cli (recommended), whisper-cli (whisper-cpp), or whisper (python)
     const candidates = [
+      '/opt/homebrew/bin/whisperkit-cli',
+      '/usr/local/bin/whisperkit-cli',
       '/opt/homebrew/bin/whisper-cli',
       '/usr/local/bin/whisper-cli',
       '/opt/homebrew/bin/whisper',
@@ -676,6 +678,12 @@ ipcMain.handle(IPC.TRANSCRIBE_AUDIO, async (_event, audioBase64: string) => {
     if (!whisperBin) {
       // Use getCliEnv() and strip escape sequences from shell output
       try {
+        const raw = execSync('/bin/zsh -lc "whence -p whisperkit-cli"', { encoding: 'utf-8', env: getCliEnv(), timeout: 3000 })
+        whisperBin = extractAbsoluteShellPath(raw) ?? ''
+      } catch {}
+    }
+    if (!whisperBin) {
+      try {
         const raw = execSync('/bin/zsh -lc "whence -p whisper-cli"', { encoding: 'utf-8', env: getCliEnv(), timeout: 3000 })
         whisperBin = extractAbsoluteShellPath(raw) ?? ''
       } catch {}
@@ -689,37 +697,49 @@ ipcMain.handle(IPC.TRANSCRIBE_AUDIO, async (_event, audioBase64: string) => {
 
     if (!whisperBin) {
       return {
-        error: 'Whisper not found. Install with: brew install whisper-cli',
+        error: 'Whisper not found. Install with: brew install whisperkit-cli',
         transcript: null,
       }
     }
 
-    const isWhisperCpp = whisperBin.includes('whisper-cli')
+    const isWhisperKit = whisperBin.includes('whisperkit-cli')
+    const isWhisperCpp = !isWhisperKit && whisperBin.includes('whisper-cli')
 
-    // Find model file — prefer multilingual (auto-detect language) over .en (English-only)
-    const modelCandidates = [
-      join(homedir(), '.local/share/whisper/ggml-base.bin'),
-      join(homedir(), '.local/share/whisper/ggml-tiny.bin'),
-      '/opt/homebrew/share/whisper-cpp/models/ggml-base.bin',
-      '/opt/homebrew/share/whisper-cpp/models/ggml-tiny.bin',
-      // Fall back to English-only models if multilingual not available
-      join(homedir(), '.local/share/whisper/ggml-base.en.bin'),
-      join(homedir(), '.local/share/whisper/ggml-tiny.en.bin'),
-      '/opt/homebrew/share/whisper-cpp/models/ggml-base.en.bin',
-      '/opt/homebrew/share/whisper-cpp/models/ggml-tiny.en.bin',
-    ]
-
+    // whisperkit-cli manages its own models — only search for ggml models if using whisper-cpp
     let modelPath = ''
-    for (const m of modelCandidates) {
-      if (existsSync(m)) { modelPath = m; break }
+    let isEnglishOnly = false
+    if (!isWhisperKit) {
+      // Find model file — prefer multilingual (auto-detect language) over .en (English-only)
+      const modelCandidates = [
+        join(homedir(), '.local/share/whisper/ggml-base.bin'),
+        join(homedir(), '.local/share/whisper/ggml-tiny.bin'),
+        '/opt/homebrew/share/whisper-cpp/models/ggml-base.bin',
+        '/opt/homebrew/share/whisper-cpp/models/ggml-tiny.bin',
+        // Fall back to English-only models if multilingual not available
+        join(homedir(), '.local/share/whisper/ggml-base.en.bin'),
+        join(homedir(), '.local/share/whisper/ggml-tiny.en.bin'),
+        '/opt/homebrew/share/whisper-cpp/models/ggml-base.en.bin',
+        '/opt/homebrew/share/whisper-cpp/models/ggml-tiny.en.bin',
+      ]
+
+      for (const m of modelCandidates) {
+        if (existsSync(m)) { modelPath = m; break }
+      }
+
+      // Detect if using an English-only model (.en suffix) — force English if so
+      isEnglishOnly = modelPath.includes('.en.')
     }
 
-    // Detect if using an English-only model (.en suffix) — force English if so
-    const isEnglishOnly = modelPath.includes('.en.')
-    log(`Transcribing with: ${whisperBin} (model: ${modelPath || 'default'}, lang: ${isEnglishOnly ? 'en' : 'auto'})`)
+    log(`Transcribing with: ${whisperBin} (${isWhisperKit ? 'whisperkit' : `model: ${modelPath || 'default'}, lang: ${isEnglishOnly ? 'en' : 'auto'}`})`)
 
     let output: string
-    if (isWhisperCpp) {
+    if (isWhisperKit) {
+      // whisperkit-cli: auto-manages CoreML models, 60s timeout for first-run model download
+      output = execSync(
+        `"${whisperBin}" transcribe --audio-path "${tmpWav}" --model-size tiny`,
+        { encoding: 'utf-8', timeout: 60000 }
+      )
+    } else if (isWhisperCpp) {
       // whisper-cpp: whisper-cli -m model -f file --no-timestamps
       if (!modelPath) {
         return {


### PR DESCRIPTION
## Summary
This PR adds support for WhisperKit CLI as the recommended transcription backend, while maintaining backward compatibility with whisper-cpp and Python Whisper. WhisperKit is now prioritized in the binary search order and installation instructions.

## Key Changes
- **Binary search priority**: Added WhisperKit CLI (`whisperkit-cli`) as the first choice in the transcription binary lookup, followed by whisper-cpp and Python Whisper
- **Shell path resolution**: Added dedicated shell environment lookup for `whisperkit-cli` using zsh before falling back to other implementations
- **Model handling**: Simplified model discovery logic to skip GGML model searches when WhisperKit is detected, since WhisperKit manages its own CoreML models automatically
- **Transcription execution**: Added WhisperKit-specific command execution path with 60-second timeout to accommodate first-run model downloads
- **Installation instructions**: Updated all user-facing documentation and installation scripts to recommend `brew install whisperkit-cli` instead of `whisper-cli`
- **Logging**: Updated transcription logging to reflect which backend is in use and handle WhisperKit's automatic model management

## Implementation Details
- WhisperKit detection is based on binary name matching (`whisperkit-cli`)
- Model path detection is now conditional—only performed for whisper-cpp, not for WhisperKit
- The `isEnglishOnly` flag is only set when using whisper-cpp with English-only models
- WhisperKit uses the `--model-size tiny` parameter for consistent behavior
- Backward compatibility is maintained: if WhisperKit is not found, the system falls back to whisper-cpp or Python Whisper

https://claude.ai/code/session_013WEaeuGiXx48UgVUwTqbdD